### PR TITLE
Ufjoin

### DIFF
--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -70,9 +70,13 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
       throw new CRM_Core_Exception("The field was not added. It already exists in this profile.");
     }
 
-
-    // @todo why is this even optional? Surely weight should just be 'managed' ??
-    if (CRM_Utils_Array::value('option.autoweight', $params, TRUE)) {
+    if (
+      ((empty($params['id']) && empty($params['weight']))
+      || !empty($params['weight']))
+      // The auto-weight concept came from the old api. It is tested in the context of
+      // replace & perhaps still has some value in that context? Or else it
+      // was just a hack on a hack to suppress some odd behaviour?
+      && (!isset($params['option.autoweight']) || $params['option.autoweight'])) {
       $params['weight'] = CRM_Core_BAO_UFField::autoWeight($params);
     }
     $ufField = CRM_Core_BAO_UFField::add($params);

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -240,9 +240,9 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
   public static function add(&$params) {
     // set values for uf field properties and save
     $ufField = new CRM_Core_DAO_UFField();
+    $ufField->copyValues($params);
 
     if (isset($params['field_name']) && !is_string($params['field_name'])) {
-      $ufField->copyValues($params);
 
       $field_type       = CRM_Utils_Array::value('field_type', $params);
       $field_name       = CRM_Utils_Array::value('field_name', $params);
@@ -270,9 +270,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
       }
 
       $ufField->phone_type_id = CRM_Utils_Array::value(3, $params['field_name'], 'NULL');
-      return $ufField->save();
     }
-    $ufField->copyValues($params);
 
     return $ufField->save();
   }

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -55,11 +55,9 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
   public static function create(&$params) {
     // CRM-14756: If the user gives the id, uf_group_id is retrieved and then set.
     if (!empty($params['id']) && empty($params['uf_group_id'])) {
-      $groupId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFField', $params['id'], 'uf_group_id', 'id');
+      $params['uf_group_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFField', $params['id'], 'uf_group_id', 'id');
     }
-    else {
-      $groupId = CRM_Utils_Array::value('uf_group_id', $params);
-    }
+    $groupId = CRM_Utils_Array::value('uf_group_id', $params);
 
     $field_name = CRM_Utils_Array::value('field_name', $params);
     if (
@@ -72,9 +70,6 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
       throw new CRM_Core_Exception("The field was not added. It already exists in this profile.");
     }
 
-    if (!(CRM_Utils_Array::value('group_id', $params))) {
-      $params['group_id'] = $groupId;
-    }
 
     // @todo why is this even optional? Surely weight should just be 'managed' ??
     if (CRM_Utils_Array::value('option.autoweight', $params, TRUE)) {
@@ -291,7 +286,7 @@ WHERE cf.id IN (" . $customFieldIds . ") AND is_multiple = 1 LIMIT 0,1";
     if (!empty($params['id'])) {
       $oldWeight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_UFField', $params['id'], 'weight', 'id');
     }
-    $fieldValues = array('uf_group_id' => $params['group_id']);
+    $fieldValues = array('uf_group_id' => $params['uf_group_id']);
     return CRM_Utils_Weight::updateOtherWeights('CRM_Core_DAO_UFField', $oldWeight, CRM_Utils_Array::value('weight', $params, 0), $fieldValues);
   }
 

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -62,7 +62,9 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField {
     }
 
     $field_name = CRM_Utils_Array::value('field_name', $params);
-    if (!CRM_Core_BAO_UFField::isValidFieldName($field_name)) {
+    if (
+      (!$field_name && empty($params['id'])) ||
+      ($field_name && !CRM_Core_BAO_UFField::isValidFieldName($field_name))) {
       throw new CRM_Core_Exception('The field_name is not valid');
     }
 

--- a/api/v3/UFField.php
+++ b/api/v3/UFField.php
@@ -52,13 +52,6 @@ function civicrm_api3_uf_field_create($params) {
 function _civicrm_api3_uf_field_create_spec(&$params) {
   $params['field_name']['api.required'] = TRUE;
   $params['uf_group_id']['api.required'] = TRUE;
-
-  $params['option.autoweight'] = array(
-    'title' => "Auto Weight",
-    'description' => "Automatically adjust weights in UFGroup to align with UFField",
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-    'api.default' => TRUE,
-  );
   $params['is_active']['api.default'] = TRUE;
 }
 

--- a/tests/phpunit/api/v3/SyntaxConformanceTest.php
+++ b/tests/phpunit/api/v3/SyntaxConformanceTest.php
@@ -647,6 +647,12 @@ class api_v3_SyntaxConformanceTest extends CiviUnitTestCase {
           'ignore_severity',
         ),
       ),
+      'UFField' => array(
+        // This is validated against options that can't be generated in an automated test context.
+        'cant_update' => array(
+          'field_name',
+        ),
+      ),
     );
     if (empty($knownFailures[$entity]) || empty($knownFailures[$entity][$key])) {
       return array();


### PR DESCRIPTION
Hi, I had a go at getting this through the tests. The 2 key things in here are that I excluded a specific field from the syntaxConformanceTest. The syntax conformance test goes through altering each field one by one & checking nothing else changes. However, I felt the requirements of the field_name field were too complex for this treatment - so I specified that field as being skipped.

The other thing I touched was weight. I wanted to remove the option.autoweight altogether since it seemed like a big cludge - but there were tests locking in the ability to opt-out of autoweight so I couldn't go that far. 

I did change the default calculation of when to do autoweight - importantly no weight calculation should take place if it is an update AND weight is not being specified - as there is no change to weight taking place.

NB - I suspect I might not have go the formatting of the ugly IFs correct ....
